### PR TITLE
added function to print object difficulty in estimation

### DIFF
--- a/kitti_object.py
+++ b/kitti_object.py
@@ -623,7 +623,14 @@ def dataset_viz(root_dir, args):
         if args.stat:
             stat_lidar_with_boxes(pc_velo, objects, calib)
             continue
-        objects[0].print_object()
+        print("======== Objects in Ground Truth ========")
+        n_obj = 0
+        for obj in objects:
+            if obj.type != 'DontCare':
+                print("=== {} object ===".format(n_obj+1))
+                obj.print_object()
+                n_obj += 1
+
         # Draw 3d box in LiDAR point cloud
         if args.show_lidar_topview_with_boxes:
            # Draw lidar top view

--- a/kitti_util.py
+++ b/kitti_util.py
@@ -70,6 +70,20 @@ class Object3d(object):
         self.t = (data[11],data[12],data[13]) # location (x,y,z) in camera coord.
         self.ry = data[14] # yaw angle (around Y-axis in camera coordinates) [-pi..pi]
 
+    def estimate_diffculty(self):
+        """ Function that estimate difficulty to detect the object as defined in kitti website"""
+        # height of the bounding box
+        bb_height = np.abs(self.xmax - self.xmin)
+
+        if bb_height >= 40 and self.occlusion == 0 and self.truncation <= 0.15:
+            return "Easy"
+        elif bb_height >= 25 and self.occlusion in [0,1] and self.truncation <= 0.30:
+            return "Moderate"
+        elif bb_height >= 25 and self.occlusion in [0,1,2] and self.truncation <= 0.50:
+            return "Hard"
+        else:
+            return "Unknown"
+
     def print_object(self):
         print('Type, truncation, occlusion, alpha: %s, %d, %d, %f' % \
             (self.type, self.truncation, self.occlusion, self.alpha))
@@ -79,6 +93,7 @@ class Object3d(object):
             (self.h, self.w, self.l))
         print('3d bbox location, ry: (%f, %f, %f), %f' % \
             (self.t[0],self.t[1],self.t[2],self.ry))
+        print('Difficulty of estimation: {}'.format(self.estimate_diffculty()))
 
 
 class Calibration(object):


### PR DESCRIPTION
In Object3D class I have added a small method that computes the difficulty to detect an object as defined in KITTI website(http://www.cvlibs.net/datasets/kitti/eval_object.php?obj_benchmark=3d):
   - Easy: Min. bounding box height: 40 Px, Max. occlusion level: Fully visible, Max. truncation: 15 %
   - Moderate: Min. bounding box height: 25 Px, Max. occlusion level: Partly occluded, Max. truncation: 30 %
   - Hard: Min. bounding box height: 25 Px, Max. occlusion level: Difficult to see, Max. truncation: 50 % 
The difficulty is printed along with all other object information with the method print_object.

Furthermore in dataset_viz function I added a small bunch of code that prints all the objects in the ground truth that are not 'DontCare'.